### PR TITLE
Add require(..) support and global + configuration object examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "mocha": "5.1.1",
     "sinon": "4.4.6",
     "sinon-chai": "3.0.0"
+  },
+  "dependencies": {
+    "request": "2.81.0"
   }
 }

--- a/rules/forceEmailVerification.js
+++ b/rules/forceEmailVerification.js
@@ -1,4 +1,7 @@
 function forceEmailVerification(user, context, callback) {
+    var request = require('request@2.81.0');
+
+    // do some kind of remote request
 
     if (!user.email_verified) {
         return callback(new UnauthorizedError('Please verify your email before logging in.'));


### PR DESCRIPTION
This wires in some more basic stuff present in the Auth0 sandbox.